### PR TITLE
Fix bugs from rent endpoint

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -18,9 +18,19 @@ class MoviesController < ApplicationController
   def rent
     user = User.find(params[:user_id])
     movie = Movie.find(params[:id])
-    movie.available_copies -= 1
-    movie.save
-    user.rented << movie
-    render json: movie
+    
+    if movie.available_copies <= 0
+      render json: {"message": "No copies available.", "success": false}, status: 400
+      return
+    end
+
+    if movie.save
+      movie.available_copies -= 1
+      user.rented << movie
+      render json: movie
+    else
+      render json: movie.errors, status: 500
+    end
+  
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   resources :movies, only: %i[index] do
     get :recommendations, on: :collection
     get :user_rented_movies, on: :collection
-    get :rent, on: :member
+    post :rent, on: :member
   end
 end


### PR DESCRIPTION
This pull request aims to fix bugs and update the verb used in the rent endpoint (movies/<movie_id>/rent?user_id=<user_id>). Here's a breakdown of the changes made:

**Fix negative copies renting**
Previously, users could rent movies even if no copies were available. With this fix, attempting to rent a movie with zero copies will result in an error message and a status code of 400. This improvement ensures that users receive appropriate feedback when they try to rent unavailable movies.

**Fix decreasing copies on error**
In the previous implementation, if an error occurred during the movie renting process, a copy would be subtracted without recording the rent. The fix addresses this issue by checking for errors before subtracting a copy and adding a rent record to the user. This enhancement maintains data consistency and prevents discrepancies between the number of available copies and recorded rents.

**Changing the endpoint verb from get to post**
The pull request also includes a change in the endpoint verb from GET to POST. According to the definition of RESTful principles, GET requests should be used for retrieving data, while POST requests are suitable for causing state changes or server-side effects. Considering that renting a movie involves modifying the system's state by adding a rental record and subtracting a movie copy, changing the verb to POST aligns better with the intended behavior of the route.
