### PR TITLE
Add pagination to movies listing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "~> 3.2.0"
 
+# Pagination gem
+gem 'kaminari'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0"
 

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.all
+    @movies = Movie.all.page(params[:page]).per(10)
     render json: @movies
   end
 


### PR DESCRIPTION
This pull request implements a simple pagination feature for the `/movies` route. Users can now specify the desired page by using the query parameter page (e.g., `/movies?page=1`).

While the pagination functionality can be extended to other routes, its inclusion will depend on the overall architecture and requirements of the service. For now, I have implemented it specifically for the listing endpoint.